### PR TITLE
UPT: window.onerror to use fatal level

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -137,7 +137,7 @@ describe('lalamove-web-logger tests', () => {
       const result = window.onerror('error message', 'index.js', 1, 1, {
         stack: 'track stack'
       });
-      expect(console.error).toHaveBeenCalledWith('[error] error message');
+      expect(console.error).toHaveBeenCalledWith('[fatal] error message');
       expect(console.error).toHaveBeenCalledTimes(1);
       expect(result).toBe(true);
     });

--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,7 @@ class Logger {
   };
 
   _handleOnError = (message, file, line, col, err) =>
-    this._logger(LEVEL_ERROR, {
+    this._logger(LEVEL_FATAL, {
       message,
       file,
       line,


### PR DESCRIPTION
Per Lalamove logging practice, we should use fatal logs for any uncaught and possibly crashing errors. Window.onerror callback is used for such cases so we just make it log fatal and call it a day.