### PR TITLE
ADD: Log level filter and setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ log.info('testing message');
 ```
 
 ## API
+#### changeLogLevels()
+Updates the log levels to call or suppress. Accepts an array of strings. Levels that are not included will be suppressed and not logged.
+During initialization, all five levels are included (debug, info, warning, error, fatal).
+```javascript
+const defaultLevels = ['debug', 'info', 'warning', 'error', 'fatal'];
+log.changeLogLevels(['info', 'warning', 'error', 'fatal']); // will suppress log.debug()
+```
 #### changeLocation()
 Change location in config.
 ```javascript

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -156,6 +156,101 @@ describe('lalamove-web-logger tests', () => {
     });
   });
 
+  describe('log levels', () => {
+    beforeEach(() => {
+      console.log = jest.fn();
+      console.warn = jest.fn();
+      console.error = jest.fn();
+    });
+
+    test('levels should be initialized when constructed', () => {
+      const log = new Logger(config);
+      const logLevels = log._config.levels;
+      expect(logLevels).toEqual(['info', 'debug', 'warning', 'error', 'fatal']);
+    });
+
+    test('changeLogLevel should change _config and lowercase the input', () => {
+      const log = new Logger(config);
+      log.changeLogLevels(['INFO', 'Debug', 'ERRor', 'FATAL']);
+      const logLevels = log._config.levels;
+      expect(logLevels).toEqual(['info', 'debug', 'error', 'fatal']);
+    });
+
+    test('should log all five levels when initialized without calling changeLogLevel', () => {
+      const log = new Logger(config);
+      let result = log.debug('debug message');
+      expect(console.log).toHaveBeenCalledWith('[debug] debug message');
+      expect(console.log).toHaveBeenCalledTimes(1);
+      expect(result).toBe(true);
+
+      result = log.info('info message');
+      expect(console.log).toHaveBeenCalledWith('[info] info message');
+      expect(console.log).toHaveBeenCalledTimes(2);
+      expect(result).toBe(true);
+
+      result = log.warning('warning message');
+      expect(console.warn).toHaveBeenCalledWith('[warning] warning message');
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(result).toBe(true);
+
+      result = log.error('error message');
+      expect(console.error).toHaveBeenCalledWith('[error] error message');
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(result).toBe(true);
+
+      result = log.fatal('fatal message');
+      expect(console.error).toHaveBeenCalledWith('[fatal] fatal message');
+      expect(console.error).toHaveBeenCalledTimes(2);
+      expect(result).toBe(true);
+    });
+
+    test('should not log debug when debug is not set on the levels', () => {
+      const log = new Logger(config);
+      log.changeLogLevels(['fatal']);
+      const result = log.debug('debug message');
+      expect(console.log).toHaveBeenCalledTimes(0);
+      expect(result).toBe(false);
+    });
+
+    test('should not log info when info is not set on the levels', () => {
+      const log = new Logger(config);
+      log.changeLogLevels(['fatal']);
+      const result = log.info('info message');
+      expect(console.log).toHaveBeenCalledTimes(0);
+      expect(result).toBe(false);
+    });
+
+    test('should not log warning when warning is not set on the levels', () => {
+      const log = new Logger(config);
+      log.changeLogLevels(['fatal']);
+      const result = log.warning('warning message');
+      expect(console.warn).toHaveBeenCalledTimes(0);
+      expect(result).toBe(false);
+    });
+
+    test('should not log error when error is not set on the levels', () => {
+      const log = new Logger(config);
+      log.changeLogLevels(['fatal']);
+      const result = log.error('error message');
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(result).toBe(false);
+    });
+
+    test('should not log fatal when fatal is not set on the levels', () => {
+      const log = new Logger(config);
+      log.changeLogLevels(['debug']);
+      const result = log.fatal('fatal message');
+      expect(console.error).toHaveBeenCalledTimes(0);
+      expect(result).toBe(false);
+    });
+
+    afterEach(() => {
+      console.log.mockClear();
+      console.warn.mockClear();
+      console.error.mockClear();
+    });
+  });
+
   describe('post to logging services', () => {
     test('should return 200', async () => {
       const log = new Logger({

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,8 @@ const defaultConfig = {
   environment: null,
   platform: null,
   clientId: null,
-  appType: null
+  appType: null,
+  levels: [LEVEL_INFO, LEVEL_DEBUG, LEVEL_WARNING, LEVEL_ERROR, LEVEL_FATAL]
 };
 
 class Logger {
@@ -36,6 +37,7 @@ class Logger {
       );
     }
     this._config = config;
+    this._config.levels = defaultConfig.levels;
     window.onerror = this._handleOnError;
   }
 
@@ -135,17 +137,28 @@ class Logger {
     this._config.clientId = id;
   }
 
-  info = (message, context) => this._logger(LEVEL_INFO, { message, context });
+  changeLogLevels(levels) {
+    this._config.levels = levels.map(r => r.toLowerCase());
+  }
 
-  debug = (message, context) => this._logger(LEVEL_DEBUG, { message, context });
+  info = (message, context) =>
+    this._config.levels.includes(LEVEL_INFO) &&
+    this._logger(LEVEL_INFO, { message, context });
+
+  debug = (message, context) =>
+    this._config.levels.includes(LEVEL_DEBUG) &&
+    this._logger(LEVEL_DEBUG, { message, context });
 
   warning = (message, context) =>
+    this._config.levels.includes(LEVEL_WARNING) &&
     this._logger(LEVEL_WARNING, { message, context });
 
   error = (message, context, backtrace) =>
+    this._config.levels.includes(LEVEL_ERROR) &&
     this._logger(LEVEL_ERROR, { message, backtrace, context });
 
   fatal = (message, context, backtrace) =>
+    this._config.levels.includes(LEVEL_FATAL) &&
     this._logger(LEVEL_FATAL, { message, backtrace, context });
 }
 


### PR DESCRIPTION
At certain environments like production, we don't really want to log certain levels like debug. So a suppressor on the log levels will be useful.